### PR TITLE
Fixed exported include folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib/
                        PATTERN "libsuitesparseconfig*"
                        PATTERN "libumfpack*"
 )
-cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include
+cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/suitesparse
           LIBRARIES amd
                     btf
                     camd


### PR DESCRIPTION
Now it includes the /suitesparse suffix. 

Closes #29 