### PR TITLE
Fixing exported library list further

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,17 +45,17 @@ install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib/
 )
 cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/suitesparse
           LIBRARIES
+                    spqr
                     cholmod
+                    ccolamd
                     amd
                     btf
                     camd
                     colamd
-                    ccolamd
                     cxsparse
                     klu
                     ldl
                     rbio
-                    spqr
                     suitesparseconfig
                     umfpack
                     lapack


### PR DESCRIPTION
Apparently #31 wasn't enough. This time I tried to revive the sane part of the former list before #28 and manually rerun on ibex-trusty. Looking good so far..