### PR TITLE
Formally depend on libsuitesparse-dev

### DIFF
--- a/system_suitesparse/package.xml
+++ b/system_suitesparse/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>system_suitesparse</name>
   <version>4.2.1</version> 
   <description>CMake scripts finding system suitesparse library</description>
@@ -8,4 +8,5 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>libsuitesparse-dev</depend>
 </package>


### PR DESCRIPTION
If this rosdep key does not exist it should be silently ignored but with custom rosdep entries it actually works :).